### PR TITLE
no_std support with std enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ categories = ["os"]
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+default = ["std"]
+std = []

--- a/src/code.rs
+++ b/src/code.rs
@@ -28,8 +28,8 @@ pub enum ExceptionCode {
     UnwindConsolidate = 0x80000029,
 }
 
-impl std::fmt::Display for ExceptionCode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ExceptionCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ExceptionCode::Invalid => write!(f, "invalid exception"),
             ExceptionCode::AccessViolation => write!(f, "the thread attempts to read from or write to a virtual address for which it does not have access"),

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 use crate::code::ExceptionCode;
 
@@ -13,7 +13,7 @@ impl Exception {
     pub(crate) fn empty() -> Self {
         Self {
             code: ExceptionCode::Invalid,
-            address: std::ptr::null_mut(),
+            address: core::ptr::null_mut(),
         }
     }
 
@@ -26,10 +26,11 @@ impl Exception {
     }
 }
 
-impl std::fmt::Display for Exception {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Exception {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.code)
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Exception {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use std::ffi::c_void;
+#![cfg_attr(not(feature = "std"), no_std)]
+use core::ffi::c_void;
 
 mod code;
 mod exception;
@@ -57,6 +58,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "std")]
     fn all_good() {
         let ex = try_seh(|| {
             let _ = *Box::new(1337);
@@ -68,7 +70,7 @@ mod tests {
     #[test]
     fn access_violation() {
         let ex = try_seh(|| unsafe {
-            std::ptr::read_volatile::<i32>(0 as _);
+            core::ptr::read_volatile::<i32>(0 as _);
         });
 
         assert_eq!(ex.is_err(), true);
@@ -79,7 +81,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     fn breakpoint() {
         let ex = try_seh(|| unsafe {
-            std::arch::asm!("int3");
+            core::arch::asm!("int3");
         });
 
         assert_eq!(ex.is_err(), true);
@@ -90,7 +92,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     fn illegal_instruction() {
         let ex = try_seh(|| unsafe {
-            std::arch::asm!("ud2");
+            core::arch::asm!("ud2");
         });
 
         assert_eq!(ex.is_err(), true);


### PR DESCRIPTION
Thanks for this crate with a pragmatic solution for SEH handling in rust.

I would like to try it in a kernel mode code. This is why I did this changes to support `no_std`

