### PR TITLE
allow dead code, which may happen if the exception handling was disabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+#![allow(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use core::{ffi::c_void, mem::MaybeUninit};
 
 mod code;


### PR DESCRIPTION
for instance, exception handling gets disabled when building on unix.